### PR TITLE
VCST-4770: Use Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,5 +60,5 @@ outputs:
   response:
     description: 'Response from upload build info endpoint of Jira Software REST API'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line runtime bump in `action.yml`; risk is limited to potential Node 24 compatibility issues in `index.js` or its dependencies.
> 
> **Overview**
> Updates the GitHub Action runtime in `action.yml` from **Node 20** to **Node 24** by changing the `runs.using` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a1b7291b4eb5a4ad311c5ac27f32ecfe58e414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->